### PR TITLE
Fix: Move elm-test to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Wejoinin signup sheet preview widget.",
   "main": "dist/js/app.js",
   "dependencies": {
-    "elm-test": "^0.18.12",
     "jquery": "3.2.1",
     "throttleit": "^1.0.0",
     "vissense": "^0.10.0"
   },
   "devDependencies": {
+    "elm-test": "^0.18.12",
     "autoprefixer": "7.1.2",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",


### PR DESCRIPTION
## Summary

- Moved `elm-test` from `dependencies` to `devDependencies` in package.json
- Fixes installation error on Apple Silicon Macs: "Unfortunately, there are no elm-test binaries available on your operating system and architecture"
- Reduces package size for consumers who don't need development tools

## Why This Fix Is Needed

When `elm-test` is listed as a runtime dependency, npm installs it for all consumers of the `prejoinin` package. This causes failures on Apple Silicon (arm64) Macs because elm-test v0.18.12 (from 2017) has no precompiled binaries for that architecture.

Testing tools should be in `devDependencies` because:
- End users don't run the package's tests
- Test files aren't distributed (only `dist/` is published)
- It reduces install size and prevents unnecessary dependency conflicts

## Test Plan

- [ ] Verify package.json is valid JSON
- [ ] Install the updated package in the wejoinin project
- [ ] Confirm elm-test is not installed in wejoinin's node_modules
- [ ] Verify elm-test can still be used for development in this repo (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)